### PR TITLE
Cleaned up an old reference to the previous standalone role 'ansible.ha-cluster-pacemaker'

### DIFF
--- a/roles/pacemaker/README.md
+++ b/roles/pacemaker/README.md
@@ -379,7 +379,7 @@ For cluster to get properly authorized it is expected that firewall is already c
 
     - hosts: cluster
       roles:
-        - { role: 'ansible.ha_cluster.pacemaker', cluster_name: 'aws-cluster', cluster_configure_fence_xvm: false, cluster_configure_fence_aws: true, cluster_configure_stonith_style: 'one-device-per-cluster', enable_repos: false, fence_aws_region: 'aws-region' }
+        - { role: 'ondrejhome.ha_cluster.pacemaker', cluster_name: 'aws-cluster', cluster_configure_fence_xvm: false, cluster_configure_fence_aws: true, cluster_configure_stonith_style: 'one-device-per-cluster', enable_repos: false, fence_aws_region: 'aws-region' }
 
 **Example playbook Resources configuration** .
 


### PR DESCRIPTION
I see the collection was originally merged (3 weeks ago as of today) from the standalone roles which included the wrong role name:

   https://github.com/OndrejHome/ansible_collection.ha_cluster/blame/master/roles/pacemaker/README.md#L382

But this was fixed later on (2 weeks ago) in the standalone role only with this commit:

   https://github.com/OndrejHome/ansible.ha-cluster-pacemaker/commit/d7da4c1e40359f5ac591f8d96ec9180d4c7448b0